### PR TITLE
Fix: Update Flask version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@
 # `Pipfile.lock` and then regenerate `requirements*.txt`.
 ################################################################################
 
-flask==1.1.2
+flask==2.1.0
 gunicorn==20.0.4
 redis==3.5.2
 rq


### PR DESCRIPTION
Fix the import error of cannot import name 'escape' from 'jinja2'

Signed-off-by: abraarsyed-rz <abraar@rulezero.com>